### PR TITLE
Fixed function name typo. Suppose that 'restore' means 'reset'

### DIFF
--- a/src/ion-range-slider.component.ts
+++ b/src/ion-range-slider.component.ts
@@ -87,7 +87,7 @@ export class IonRangeSliderComponent implements OnChanges{
     }
 
     restore() {
-        jQuery(this.inputElem).data("ionRangeSlider").restore()
+        jQuery(this.inputElem).data("ionRangeSlider").reset()
     }
 
     destroy() {

--- a/src/ion-range-slider.component.ts
+++ b/src/ion-range-slider.component.ts
@@ -86,7 +86,7 @@ export class IonRangeSliderComponent implements OnChanges{
         jQuery(this.inputElem).data("ionRangeSlider").update(data);
     }
 
-    restore() {
+    reset() {
         jQuery(this.inputElem).data("ionRangeSlider").reset()
     }
 


### PR DESCRIPTION
Because there is no such method in base lib:
https://github.com/IonDen/ion.rangeSlider#public-methods

and for me it caused error:
`ERROR TypeError: jQuery(...).data(...).restore is not a function`
