### PR TITLE
Upgrade to ion-rangeslider v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## ng2-ion-range-slider
-[Ion Range Slider](https://github.com/IonDen/ion.rangeSlider) now optimized for easy use as an importable Angular 2 Module and installable using npm.
+[Ion Range Slider](https://github.com/IonDen/ion.rangeSlider) now optimized for easy use as an importable Angular Module and installable using npm.
 
 ### Demos and Sample Usage
 
@@ -26,10 +26,10 @@ If you use angular-cli, add ``jquery`` and ``ion-range-slider`` to the scripts s
     {
       ...
       "scripts": [
-            "../node_modules/jquery/dist/jquery.min.js", 
+            "../node_modules/jquery/dist/jquery.min.js",
             "../node_modules/ion-rangeslider/js/ion.rangeSlider.min.js"
       ],
-      ...   
+      ...
 ```
 
 Also add the ion-range-slider style and skin css to the styles section in your ``.angular-cli.json``
@@ -40,10 +40,9 @@ Also add the ion-range-slider style and skin css to the styles section in your `
     {
       ...
       "styles": [
-              "../node_modules/ion-rangeslider/css/ion.rangeSlider.css",
-              "../node_modules/ion-rangeslider/css/ion.rangeSlider.skinFlat.css"
+              "../node_modules/ion-rangeslider/css/ion.rangeSlider.min.css"
       ],
-      ...   
+      ...
 ```
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-export * from './lib/ion-range-slider.module'
-export * from './lib/ion-range-slider.component'
+export * from './src/ion-range-slider.module'
+export * from './src/ion-range-slider.component'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng2-ion-range-slider",
   "version": "2.0.0",
-  "description": "Ion Range Slider for AngularJS 2",
+  "description": "Ion Range Slider for Angular",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
@@ -14,7 +14,6 @@
   },
   "keywords": [
     "Angular",
-    "2",
     "ion",
     "range",
     "slider"
@@ -38,6 +37,6 @@
   },
   "dependencies": {
     "@types/jquery": "^2.0.40",
-    "ion-rangeslider": "^2.1.6"
+    "ion-rangeslider": "^2.3.0"
   }
 }

--- a/src/ion-range-slider.component.ts
+++ b/src/ion-range-slider.component.ts
@@ -1,7 +1,6 @@
 import {ElementRef, OnChanges, SimpleChanges, Input, EventEmitter, Output, Component} from "@angular/core";
-import 'ion-rangeslider'
 
-import * as jQuery from "jquery";
+declare let jQuery: any;
 
 @Component({
     selector: 'ion-range-slider',


### PR DESCRIPTION
Upgrade to ion-rangeslider v2.3.0.

Explicit import of jQuery creates a new instance of jQuery if you also include jQuery in angular.json (which is the right way of doing it for broad backwards compatibility with jQuery plugins). This causes ion-rangeslider to attach itself to the wrong instance of jQuery, thus, making itself unavailable to ng2-ion-range-slider loaded to a different zone in Angular.

Also removed references to Angular 2 as anything 2+ is Angular these days.